### PR TITLE
Change ETH/DAI transaction fetching to be provider based.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,18 @@ common: &common
         key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py37:
+  py37-core:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37
+          TOXENV: py37-core
+  py37-integration:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-integration
   lint:
     <<: *common
     docker:
@@ -57,5 +63,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - py37
+      - py37-core
+      - py37-integration
       - lint

--- a/pretix_eth/providers.py
+++ b/pretix_eth/providers.py
@@ -1,0 +1,83 @@
+from abc import ABC, abstractmethod
+from typing import NamedTuple, Tuple
+
+import requests
+
+from eth_utils.typing.misc import ChecksumAddress
+from eth_typing import Hash32
+
+from eth_utils import (
+    to_bytes,
+    to_checksum_address,
+)
+
+
+class Transaction(NamedTuple):
+    hash: Hash32
+    sender: ChecksumAddress
+    success: bool
+    timestamp: int
+    to: ChecksumAddress
+    value: int
+
+
+class TransactionProviderAPI(ABC):
+    @abstractmethod
+    def get_transactions(self, to_address: ChecksumAddress) -> Tuple[Transaction, ...]:
+        ...
+
+
+class BlockscoutTransactionProvider(TransactionProviderAPI):
+    def get_transactions(self, from_address: ChecksumAddress) -> Tuple[Transaction, ...]:
+        response = requests.get(
+            f'https://blockscout.com/poa/core/api?module=account&action=txlist&address={from_address}',  # noqa: E501
+        )
+        # TODO: handle http errors here
+        response.raise_for_status()
+        response_data = response.json()
+        if response_data['status'] != "1":
+            raise Exception("TODO: real exception and message")
+        return tuple(
+            Transaction(
+                hash=to_bytes(hexstr=raw_transaction['hash']),
+                sender=to_checksum_address(raw_transaction['from']),
+                success=(raw_transaction['txreceipt_status'] == 1),
+                timestamp=int(raw_transaction['timeStamp']),
+                to=to_checksum_address(raw_transaction['to']),
+                value=int(raw_transaction['value']),
+            ) for raw_transaction in response_data['result']
+        )
+
+
+class Transfer(NamedTuple):
+    hash: Hash32
+    sender: ChecksumAddress
+    timestamp: int
+    success: bool
+    to: ChecksumAddress
+    value: int
+
+
+class TokenProviderAPI(ABC):
+    @abstractmethod
+    def get_ERC20_transfers(self, to_address: ChecksumAddress) -> Tuple[Transfer, ...]:
+        ...
+
+
+class BlockscoutTokenProvider(TokenProviderAPI):
+    def get_ERC20_transfers(self, from_address: ChecksumAddress) -> Tuple[Transfer, ...]:
+        response = requests.get(
+            f'https://blockscout.com/poa/dai/api?module=account&action=txlist&address={from_address}',  # noqa: E501
+        )
+        response.raise_for_status()
+        transfer_data = response.json()
+        return tuple(
+            Transfer(
+                hash=to_bytes(hexstr=raw_transfer['hash']),
+                sender=to_checksum_address(raw_transfer['from']),
+                success=(raw_transfer['txreceipt_status'] == 1),
+                timestamp=int(raw_transfer['timeStamp']),
+                to=to_checksum_address(raw_transfer['to']),
+                value=int(raw_transfer['value']),
+            ) for raw_transfer in transfer_data['result']
+        )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
+addopts= --showlocals
+xfail_strict=true
+log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
+log_date_format = %m-%d %H:%M:%S
 DJANGO_SETTINGS_MODULE=pretix.testutils.settings

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,12 @@ cmdclass = {
 
 extras_require = {
     'test': [
-        'pytest>=3.2.1,<4',
+        'pytest>=5.0.1,<6',
         'pytest-django>=3.5.1,<4',
     ],
     'lint': [
         'flake8>=3.5.0,<4',
+        "mypy==0.701",
     ],
     'dev': [
         'tox>=1.8.0,<2',
@@ -52,6 +53,9 @@ setup(
     install_requires=[
         "Django==2.2.2",
         "pretix==2.8.2",
+        "eth-typing>=2.1.0,<3",
+        "eth-utils>=1.6.1,<2",
+        "eth-hash[pycryptodome]>=0.2.0,<0.3",
     ],
     python_requires='>=3.7, <4',
     extras_require=extras_require,

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,47 @@
+import datetime
+
+from django.utils import timezone
+
+import pytest
+
+from pretix.base.models import (
+    Event,
+    Organizer,
+)
+
+from pretix_eth.payment import Ethereum
+
+
+ETH_ADDRESS = '0xeee0123400000000000000000000000000000000'
+DAI_ADDRESS = '0xda10123400000000000000000000000000000000'
+
+
+@pytest.fixture
+def event(transactional_db):
+    now = timezone.now()
+    presale_start_at = now + datetime.timedelta(days=2)
+    presale_end_at = now + datetime.timedelta(days=6)
+    start_at = now + datetime.timedelta(days=7)
+    end_at = now + datetime.timedelta(days=14)
+
+    organizer = Organizer.objects.create(
+        name='Ethereum Foundation',
+        slug='ethereum-foundation',
+    )
+    event = Event.objects.create(
+        name='Devcon',
+        slug='devcon',
+        organizer=organizer,
+        date_from=start_at,
+        date_to=end_at,
+        presale_start=presale_start_at,
+        presale_end=presale_end_at,
+        location='Osaka',
+    )
+    return event
+
+
+@pytest.fixture
+def provider(event):
+    provider = Ethereum(event)
+    return provider

--- a/tests/core/test_ethereum_payment_provider.py
+++ b/tests/core/test_ethereum_payment_provider.py
@@ -1,49 +1,12 @@
-import datetime
-
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import timezone
 from django.test import RequestFactory
 from django.contrib.sessions.backends.db import SessionStore
 
 import pytest
 
-from pretix.base.models import (
-    Event,
-    Organizer,
-)
-
-from pretix_eth.payment import Ethereum
-
 
 ETH_ADDRESS = '0xeee0123400000000000000000000000000000000'
 DAI_ADDRESS = '0xda10123400000000000000000000000000000000'
-
-
-@pytest.fixture
-def event(transactional_db):
-    now = timezone.now()
-    presale_start_at = now + datetime.timedelta(days=2)
-    presale_end_at = now + datetime.timedelta(days=6)
-    start_at = now + datetime.timedelta(days=7)
-    end_at = now + datetime.timedelta(days=14)
-
-    organizer = Organizer.objects.create(name='Ethereum Foundation')
-    event = Event.objects.create(
-        name='Devcon',
-        organizer=organizer,
-        date_from=start_at,
-        date_to=end_at,
-        presale_start=presale_start_at,
-        presale_end=presale_end_at,
-        location='Osaka',
-    )
-    return event
-
-
-@pytest.fixture
-def provider(event):
-    provider = Ethereum(event)
-    return provider
 
 
 @pytest.mark.django_db
@@ -59,6 +22,8 @@ def test_provider_settings_form_fields(provider):
 
     assert 'ETH' in form_fields
     assert 'DAI' in form_fields
+    assert 'TRANSACTION_PROVIDER' in form_fields
+    assert 'TOKEN_PROVIDER' in form_fields
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_provider_payment_execution.py
+++ b/tests/core/test_provider_payment_execution.py
@@ -1,0 +1,153 @@
+import decimal
+import time
+
+import pytest
+
+from django.test import RequestFactory
+from django.utils import timezone
+from django.contrib.sessions.backends.db import SessionStore
+
+from pretix.base.models import Order, OrderPayment
+
+from pretix_eth.providers import (
+    TokenProviderAPI,
+    Transfer,
+    TransactionProviderAPI,
+    Transaction,
+)
+
+
+ZERO_HASH = b'\x00' * 32
+ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+ETH_ADDRESS = '0xeee0123400000000000000000000000000000000'
+DAI_ADDRESS = '0xda10123400000000000000000000000000000000'
+
+
+class FixtureTransactionProvider(TransactionProviderAPI):
+    def __init__(self, transactions):
+        self._transactions = transactions
+
+    def get_transactions(self, from_address):
+        return self._transactions
+
+
+class FixtureTokenProvider(TokenProviderAPI):
+    def __init__(self, transfers):
+        self._transfers = transfers
+
+    def get_ERC20_transfers(self, from_address):
+        return self._transfers
+
+
+@pytest.fixture
+def order_and_payment(transactional_db, event):
+    order = Order.objects.create(
+        event=event,
+        email='test@example.com',
+        locale='en_US',
+        datetime=timezone.now(),
+        total=decimal.Decimal('100.00'),
+        status=Order.STATUS_PENDING,
+    )
+    payment = OrderPayment.objects.create(
+        order=order,
+        amount='100.00',
+        state=OrderPayment.PAYMENT_STATE_PENDING,
+    )
+    return order, payment
+
+
+@pytest.mark.django_db
+def test_provider_execute_successful_payment_in_ETH(provider, order_and_payment):
+    order, payment = order_and_payment
+
+    # setup a transaction provider which returns a fixed list of transactions
+    # which will satisfy our order conditions
+    transactions = (
+        Transaction(
+            hash=ZERO_HASH,
+            sender=ZERO_ADDRESS,
+            success=True,
+            to=ETH_ADDRESS,
+            timestamp=int(time.time()),
+            value=100,
+        ),
+    )
+    tx_provider = FixtureTransactionProvider(transactions)
+    provider.transaction_provider = tx_provider
+    assert provider.transaction_provider is tx_provider
+
+    assert order.status == order.STATUS_PENDING
+    assert payment.state == payment.PAYMENT_STATE_PENDING
+
+    provider.settings.set('ETH', ETH_ADDRESS)
+
+    factory = RequestFactory()
+    session = SessionStore()
+    session.create()
+
+    # setup all the necessary session data for the payment to be valid
+    session['payment_ethereum_fm_address'] = ZERO_ADDRESS
+    session['payment_ethereum_fm_currency'] = 'ETH'
+    session['payment_ethereum_time'] = int(time.time()) - 10
+    session['payment_ethereum_amount'] = 100
+
+    request = factory.get('/checkout')
+    request.event = provider.event
+    request.session = session
+
+    provider.execute_payment(request, payment)
+
+    order.refresh_from_db()
+    payment.refresh_from_db()
+
+    assert order.status == order.STATUS_PAID
+    assert payment.state == payment.PAYMENT_STATE_CONFIRMED
+
+
+@pytest.mark.django_db
+def test_provider_execute_successful_payment_in_DAI(provider, order_and_payment):
+    order, payment = order_and_payment
+
+    # setup a transaction provider which returns a fixed list of transactions
+    # which will satisfy our order conditions
+    transfers = (
+        Transfer(
+            hash=ZERO_HASH,
+            sender=ZERO_ADDRESS,
+            success=True,
+            to=DAI_ADDRESS,
+            timestamp=int(time.time()),
+            value=100,
+        ),
+    )
+    token_provider = FixtureTokenProvider(transfers)
+    provider.token_provider = token_provider
+    assert provider.token_provider is token_provider
+
+    assert order.status == order.STATUS_PENDING
+    assert payment.state == payment.PAYMENT_STATE_PENDING
+
+    provider.settings.set('DAI', DAI_ADDRESS)
+
+    factory = RequestFactory()
+    session = SessionStore()
+    session.create()
+
+    # setup all the necessary session data for the payment to be valid
+    session['payment_ethereum_fm_address'] = ZERO_ADDRESS
+    session['payment_ethereum_fm_currency'] = 'DAI'
+    session['payment_ethereum_time'] = int(time.time()) - 10
+    session['payment_ethereum_amount'] = 100
+
+    request = factory.get('/checkout')
+    request.event = provider.event
+    request.session = session
+
+    provider.execute_payment(request, payment)
+
+    order.refresh_from_db()
+    payment.refresh_from_db()
+
+    assert order.status == order.STATUS_PAID
+    assert payment.state == payment.PAYMENT_STATE_CONFIRMED

--- a/tests/integration/test_token_provider.py
+++ b/tests/integration/test_token_provider.py
@@ -1,0 +1,41 @@
+from pretix_eth.providers import BlockscoutTokenProvider
+
+from eth_utils import (
+    is_boolean,
+    is_checksum_address,
+    is_bytes,
+    is_integer,
+)
+
+
+META_CARTEL_ADDRESS = '0xa1c3Eb21cD44F0433c6be936AD84D20b70B564D3'
+
+
+def test_blockscout_transaction_provider():
+    provider = BlockscoutTokenProvider()
+    transfers = provider.get_ERC20_transfers(META_CARTEL_ADDRESS)
+    assert len(transfers) > 0
+    assert all(
+        is_bytes(tx.hash) and len(tx.hash) == 32
+        for tx in transfers
+    )
+    assert all(
+        is_checksum_address(tx.sender)
+        for tx in transfers
+    )
+    assert all(
+        is_checksum_address(tx.to)
+        for tx in transfers
+    )
+    assert all(tuple(
+        is_integer(tx.value)
+        for tx in transfers
+    ))
+    assert all(
+        is_integer(tx.timestamp)
+        for tx in transfers
+    )
+    assert all(
+        is_boolean(tx.success)
+        for tx in transfers
+    )

--- a/tests/integration/test_transaction_provider.py
+++ b/tests/integration/test_transaction_provider.py
@@ -1,0 +1,41 @@
+from pretix_eth.providers import BlockscoutTransactionProvider
+
+from eth_utils import (
+    is_boolean,
+    is_checksum_address,
+    is_bytes,
+    is_integer,
+)
+
+
+ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+
+def test_blockscout_transaction_provider():
+    provider = BlockscoutTransactionProvider()
+    transactions = provider.get_transactions(ZERO_ADDRESS)
+    assert len(transactions) > 0
+    assert all(
+        is_bytes(tx.hash) and len(tx.hash) == 32
+        for tx in transactions
+    )
+    assert all(
+        is_checksum_address(tx.sender)
+        for tx in transactions
+    )
+    assert all(
+        is_checksum_address(tx.to)
+        for tx in transactions
+    )
+    assert all(tuple(
+        is_integer(tx.value)
+        for tx in transactions
+    ))
+    assert all(
+        is_integer(tx.timestamp)
+        for tx in transactions
+    )
+    assert all(
+        is_boolean(tx.success)
+        for tx in transactions
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37}
+    py{37}-{core,integration}
     lint
 
 [flake8]
@@ -10,7 +10,8 @@ exclude= venv,docs
 [testenv]
 usedevelop=True
 commands=
-    pytest {posargs:tests}
+    core: pytest {posargs:tests/core}
+    integration: pytest {posargs:tests/integration}
 extras=
 	test
 basepython =
@@ -20,4 +21,5 @@ basepython =
 basepython=python3.7
 extras=lint
 commands=
-	flake8 {toxinidir}/tests {toxinidir}/pretix_eth {toxinidir}/setup.py
+    flake8 {toxinidir}/tests {toxinidir}/pretix_eth {toxinidir}/setup.py
+    mypy --ignore-missing-imports --strict pretix_eth/providers.py --follow-imports skip


### PR DESCRIPTION
### What was wrong?

The payment provider currently uses data fetched from the Ethplorer and Blockscout APIs to determine if a payment was made.

- The EthPlorer API doesn't correctly report ETH transaction values: #25 

In addition, this code isn't very testable since it is hard coded to always use live data.

### How was it fixed?

To fix issues #25 we now use Blockscout for both DAI and ETH transfers.

In order to make this code testable, this PR adds two new settings to the payment provider.

- `TRANSACTION_PROVIDER`
- `TOKEN_PROVIDER`

Both of these are optional and left empty they default to using the Blockscout API to query about account transactions and token transfers.

This also adds simple tests for the *happy path* for purchasing with both DAI and ETH.  More tests will be added next to validate and fix the security issue #8 

![12765808_f1024](https://user-images.githubusercontent.com/824194/60987890-c6f7ce80-a2ff-11e9-9154-141f25b803a3.jpg)


#### Cute Animal Picture

![Cute animal picture]()
