### PR TITLE
Show rates on payment page and populate transaction hash from url parameter

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -281,7 +281,7 @@ class Ethereum(BasePaymentProvider):
         if 'txhash' in request.GET:
             request.session['payment_ethereum_txn_hash'] = request.GET.get('txhash')
         if 'currency' in request.GET:
-            request.session['payment_ethereum_currency_type'] = request.GET.get('txhash')
+            request.session['payment_ethereum_currency_type'] = request.GET.get('currency')
         form = self.payment_form(request)
         template = get_template('pretix_eth/checkout_payment_form.html')
         ctx = {

--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -287,7 +287,7 @@ class Ethereum(BasePaymentProvider):
         ctx = {
             'request': request,
             'form': form,
-            'WEI_per_ticket': from_wei(self._get_rates_from_api(total, 'ETH'), 'ether'),
+            'ETH_per_ticket': from_wei(self._get_rates_from_api(total, 'ETH'), 'ether'),
             'DAI_per_ticket': self._get_rates_from_api(total, 'DAI'),
             'ETH_address': self.settings.get('ETH'),
             'DAI_address': self.settings.get('DAI'),

--- a/pretix_eth/templates/pretix_eth/checkout_payment_form.html
+++ b/pretix_eth/templates/pretix_eth/checkout_payment_form.html
@@ -1,24 +1,16 @@
-{% load i18n %}
-{% load ibanformat %}
-
-<p>
-    {% blocktrans trimmed %}
-    After completing your purchase, we will ask you to transfer the money to
-    the following bank account, using a personal reference code:
-    {% endblocktrans %}
-</p>
-
-<address>
-    {% if settings.bank_details_type == "sepa" %}
-        {% trans "Account holder" %}: {{ settings.bank_details_sepa_name }}<br>
-        {% trans "IBAN" %}: {{ settings.bank_details_sepa_iban|ibanformat }}<br>
-        {% trans "BIC" %}: {{ settings.bank_details_sepa_bic }}<br>
-        {% trans "Bank" %}: {{ settings.bank_details_sepa_bank }}<br>
+{% load bootstrap3 %}
+<div class="form-horizontal">
+    {% if ETH_address %}
+      <div class="ETH-crypto-payment-details">
+        <p>Send {{ WEI_per_ticket }} ETH to {{ ETH_address }}</p>
+      </div>
     {% endif %}
-    {% if details %}
-        {{ details|linebreaksbr }}<br>
+    {% if DAI_address %}
+      <div class="ETH-crypto-payment-details">
+        <p>Send {{ DAI_per_ticket }} DAI to {{ DAI_address }}</p>
+      </div>
     {% endif %}
-    <strong>
-        {% trans "We will assign you a personal reference code to use after you completed the order." %}
-    </strong>
-</address>
+
+
+    {% bootstrap_form form layout='horizontal' %}
+</div>

--- a/pretix_eth/templates/pretix_eth/checkout_payment_form.html
+++ b/pretix_eth/templates/pretix_eth/checkout_payment_form.html
@@ -2,7 +2,7 @@
 <div class="form-horizontal">
     {% if ETH_address %}
       <div class="ETH-crypto-payment-details">
-        <p>Send {{ WEI_per_ticket }} ETH to {{ ETH_address }}</p>
+        <p>Send {{ ETH_per_ticket }} ETH to {{ ETH_address }}</p>
       </div>
     {% endif %}
     {% if DAI_address %}

--- a/tests/core/test_provider_payment_execution.py
+++ b/tests/core/test_provider_payment_execution.py
@@ -86,8 +86,8 @@ def test_provider_execute_successful_payment_in_ETH(provider, order_and_payment)
     session.create()
 
     # setup all the necessary session data for the payment to be valid
-    session['payment_ethereum_fm_txn_hash'] = to_hex(ZERO_HASH)
-    session['payment_ethereum_fm_currency_type'] = 'ETH'
+    session['payment_ethereum_txn_hash'] = to_hex(ZERO_HASH)
+    session['payment_ethereum_currency_type'] = 'ETH'
     session['payment_ethereum_time'] = int(time.time()) - 10
     session['payment_ethereum_amount'] = 100
 
@@ -132,8 +132,8 @@ def test_provider_execute_successful_payment_in_DAI(provider, order_and_payment)
     session.create()
 
     # setup all the necessary session data for the payment to be valid
-    session['payment_ethereum_fm_txn_hash'] = to_hex(ZERO_HASH)
-    session['payment_ethereum_fm_currency_type'] = 'DAI'
+    session['payment_ethereum_txn_hash'] = to_hex(ZERO_HASH)
+    session['payment_ethereum_currency_type'] = 'DAI'
     session['payment_ethereum_time'] = int(time.time()) - 10
     session['payment_ethereum_amount'] = 100
 


### PR DESCRIPTION
### What was wrong?

- If paying with ETH/DAI users need to know how much and where to send it.
- If using web3connect, the transaction hash needs to auto-populate into the form.

### How was it fixed?

- Custom template to render the form that now shows the data (in a really ugly way)
- Check url parameter for transaction hash on the payment form page and populate the form with it.

Looks like this.

![Screenshot from 2019-07-12 15-38-19](https://user-images.githubusercontent.com/824194/61159994-382fb100-a4bb-11e9-997c-eda588efe0f8.png)

This also cleans up a few flaws.

- Money is now handled properly using `decimal.Decimal`
- ETH value is now tracked in `WEI` and is quantized such that it will only use up to 5 decimal places when rendered as ETH
- Fixed some mis-use of different currency types.


#### Cute Animal Picture

![pet-rat-photography-diane-ozdamar-9](https://user-images.githubusercontent.com/824194/61159888-d8390a80-a4ba-11e9-85f8-899256bde604.jpg)

