### PR TITLE
Update base migrations for transaction migration

### DIFF
--- a/pretix_eth/migrations/0001_initial.py
+++ b/pretix_eth/migrations/0001_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('pretixbase', '0127_auto_20190711_0705'),
+        ('pretixbase', '0122_orderposition_web_secret'),
     ]
 
     operations = [


### PR DESCRIPTION
### What was wrong?

Migrations were too far ahead of the version on staging.

### How was it fixed?

Explicitly set the base migration for the transaction migration to an earlier one.