### PR TITLE
Update transaction model to use CharField for txn hash

### DIFF
--- a/pretix_eth/migrations/0001_initial.py
+++ b/pretix_eth/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='Transaction',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False)),
-                ('txn_hash', models.BinaryField(max_length=32, unique=True)),
+                ('txn_hash', models.CharField(max_length=66, unique=True)),
                 ('order_payment', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='pretixbase.OrderPayment')),  # noqa: E501
             ],
         ),

--- a/pretix_eth/models.py
+++ b/pretix_eth/models.py
@@ -11,5 +11,5 @@ class Transaction(models.Model):
     proof of payment. Storing this information allows us to prevent the same
     transaction from being used more than once for payment.
     """
-    txn_hash = models.BinaryField(max_length=32, unique=True)
+    txn_hash = models.CharField(max_length=66, unique=True)
     order_payment = models.ForeignKey(OrderPayment, on_delete=models.PROTECT)


### PR DESCRIPTION
### What was wrong?

MySQL doesn't like BLOB fields that have indices or unique constraints.

### How was it fixed?

Changed the transaction `txn_hash` field to be a `CharField` (`VARCHAR` when using MySQL).
