### PR TITLE
Update pending template

### DIFF
--- a/pretix_eth/templates/pretix_eth/pending.html
+++ b/pretix_eth/templates/pretix_eth/pending.html
@@ -2,12 +2,9 @@
 {% load static %}
 <script type="text/javascript" src="{% static "pretix_eth/check.js" %}"></script>
 <p>
-    <strong>{% blocktrans %}Deposit {{ amount }} {{ coin }} into {{ payment_info }}{% endblocktrans %}</strong>
-</p>
-<p>
     {% blocktrans trimmed %}
-    We're waiting for a successful deposit to the address provided. Kindly deposit to the address and wait for confirmation. Please contact us if this
-    takes more than an hour after you've made a deposit.
+    We'll verify that a deposit was made to the correct address. Once this
+    has been done, you'll receive a confirmation email.
     {% endblocktrans %}
 </p>
 


### PR DESCRIPTION
### What was wrong?

Fixed some wording in the final "order pending" to remove instructions that suggest we haven't yet confirmed a transaction.