### PR TITLE
Switch checkout page domain

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -234,7 +234,7 @@ class Ethereum(BasePaymentProvider):
         else:
             raise ImproperlyConfigured(f'Unrecognized currency: {currency_type}')  # noqa: E501
 
-        web3connect_url = f'https://checkout.web3connect.com/?currency={currency_type}&amount={amount_in_ether}&to={wallet_address}'  # noqa: E501
+        web3connect_url = f'https://pretix.web3connect.com/?currency={currency_type}&amount={amount_in_ether}&to={wallet_address}'  # noqa: E501
 
         ctx = {
             'erc_681_url': erc_681_url,


### PR DESCRIPTION
Previously hosted at `checkout.web3connect.com` and now at `pretix.web3connect.com`

Source code: https://github.com/pedrouid/web3connect-pretix