### PR TITLE
Include payment id in amount stored in info field

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -182,12 +182,14 @@ class Ethereum(BasePaymentProvider):
     def execute_payment(self, request: HttpRequest, payment: OrderPayment):
         currency_type = request.session['payment_ethereum_currency_type']
         payment_timestamp = request.session['payment_ethereum_time']
-        payment_amount = request.session['payment_ethereum_amount']
+
+        truncated_amount_in_wei = request.session['payment_ethereum_amount']
+        amount_plus_payment_id = truncated_amount_in_wei + payment.id
 
         payment.info_data = {
             'currency_type': currency_type,
             'time': payment_timestamp,
-            'amount': payment_amount,
+            'amount': amount_plus_payment_id,
         }
         payment.save(update_fields=['info'])
 
@@ -217,9 +219,8 @@ class Ethereum(BasePaymentProvider):
 
         wallet_address = self.settings.WALLET_ADDRESS
         currency_type = payment.info_data['currency_type']
+        amount_plus_payment_id = payment.info_data['amount']
 
-        truncated_amount_in_wei = payment.info_data['amount']
-        amount_plus_payment_id = truncated_amount_in_wei + payment.id
         amount_in_ether = from_wei(amount_plus_payment_id, 'ether')
 
         if currency_type == 'ETH':


### PR DESCRIPTION
### What was wrong?

The payment id encoding didn't apply to the amount value stored in a payment's info field.

### How was it fixed?

Moved the payment id encoding to an earlier stage in the checkout process to fix this.

#### Cute Animal Picture

![Cute animal picture](https://assets.rbl.ms/230010/980x.jpg)
