### PR TITLE
Fix key error after aborted payment change process

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -71,8 +71,7 @@ class Ethereum(BasePaymentProvider):
     @property
     def settings_form_fields(self):
         form_fields = OrderedDict(
-            list(super().settings_form_fields.items())
-            + [
+            list(super().settings_form_fields.items()) + [
                 ('WALLET_ADDRESS', forms.CharField(
                     label=_('Wallet address'),
                     required=True
@@ -133,8 +132,7 @@ class Ethereum(BasePaymentProvider):
         )
 
         form_fields = OrderedDict(
-            list(super().payment_form_fields.items())
-            + [
+            list(super().payment_form_fields.items()) + [
                 ('currency_type', forms.ChoiceField(
                     label=_('Payment currency'),
                     help_text=_('Select the currency you will use for payment.'),

--- a/pretix_eth/templates/pretix_eth/pending.html
+++ b/pretix_eth/templates/pretix_eth/pending.html
@@ -1,30 +1,73 @@
 {% load i18n %}
 {% load static %}
 
-<a id="pretix-eth-qr-anchor" href="{{ erc_681_url }}" class="collapse"></a>
 <br/><br/>
-<p>
-    <strong>Please pay for your ticket! Be sure to not change the amount (e.g. round up) even if your wallet allows you to as the order is encoded in the amount.</strong>
-</p>
-You have the following options to trigger the payment:
-<p>
-<ul>
-  <li>
-    via this <a href="https://eips.ethereum.org/EIPS/eip-681">ERC-681</a> QR-Code:<br/><br/>
-    <div id="pretix-eth-qr-div"></div>
-    <script type="text/javascript" src="{% static "pretix_eth/generate_qrcode.js" %}"></script>
-  </li>
-  <li>
-    <a target="blank" rel="noreferrer noopener" href="{{ web3connect_url }}">via Web3Connect</a> (allows you to pay with WalletConnect and MetatMask)
-  </li>
-  <li>
-   manually pay <b>exactly</b> {{ amount_manual }} to {{ wallet_address }}. Please only do this if you know what you are doing and use the ERC-681 or web3connect methods otherwise.
-  </li>
-</ul>
-</p>
 
-<p>
+{% if payment_is_valid %}
+
+  <a id="pretix-eth-qr-anchor" href="{{ erc_681_url }}" class="collapse"></a>
+
+  <p>
+    <strong>
+      {% blocktrans trimmed %}
+      Please pay for your ticket!  <em>DO NOT</em> change the amount (e.g. round
+      up) even if your wallet allows you to do so.  If you do, we won't be able
+      to associate your payment with your order.
+      {% endblocktrans %}
+    </strong>
+  </p>
+
+  {% trans "You have the following options to trigger the payment:" %}
+  <p>
+    <ul>
+      <li>
+        {% blocktrans trimmed %}
+        Via this <a href="https://eips.ethereum.org/EIPS/eip-681">ERC-681</a>
+        QR-Code:
+        {% endblocktrans %}
+        <div id="pretix-eth-qr-div"></div>
+        <script type="text/javascript" src="{% static "pretix_eth/generate_qrcode.js" %}"></script>
+      </li>
+
+      <li>
+        <a target="blank" rel="noreferrer noopener" href="{{ web3connect_url }}">
+          {% trans "Via Web3Connect" %}
+        </a>
+        ({% trans "allows you to pay with WalletConnect and MetaMask" %}).
+      </li>
+
+      <li>
+        {% blocktrans trimmed %}
+        Manually pay <strong>exactly</strong> {{ amount_manual }} to {{ wallet_address }}.
+        Please only do this if you know what you are doing. Otherwise, use the
+        ERC-681 or Web3Connect methods.
+        {% endblocktrans %}
+      </li>
+    </ul>
+  </p>
+
+  <p>
     {% blocktrans trimmed %}
-    If you already paid - please just stay patient - the transactions are currently just checked once a day. You will get an email - stay patient. If you want to improve this submit a PR this github repository: <a href="https://github.com/esPass/pretix-eth-payment-plugin">https://github.com/esPass/pretix-eth-payment-plugin</a>
+    If you already paid, please be patient!  Transactions are currently checked
+    just once a day.  Once this happens, you will get an email.  If you want to
+    improve this process, submit a PR to this github repository:
     {% endblocktrans %}
-</p>
+    <a href="https://github.com/esPass/pretix-eth-payment-plugin">
+      https://github.com/esPass/pretix-eth-payment-plugin
+    </a>
+  </p>
+
+{% else %}
+
+  <p>
+    <strong>
+      {% blocktrans trimmed %}
+      Your order is not yet complete.  You may have tried to change the payment
+      method but cancelled the process midway.  Please choose a payment method
+      by clicking the "Re-try payment or choose another payment method" button
+      below.
+      {% endblocktrans %}
+    </strong>
+  </p>
+
+{% endif %}


### PR DESCRIPTION
### What was wrong?

Fixes #68.  Also, cleans up some wording and adds translation directives in the payment pending template.

### How was it fixed?

The problem is that pretix creates a new payment object every time someone begins the payment change process.  However, if they abort that process without clicking the "Pay now" button in the confirm view, then the most recent payment object for an order won't contain any information about what currency was selected or what amount of that currency they should pay.

The simplest fix for this is to call `execute_payment` inside of the `payment_prepare` method.  However, this may surprise the user since it will effectively change the payment method before they have clicked "Pay now" in the checkout confirm view.

A more correct fix, and the one that was used in this PR, is to add a private method on the payment backend that checks for required info in a payment's `info_data` field.  This method is used to tell the payment pending view whether or not the most recent payment contains enough data to generate payment instructions.  If not, it advises the user to repeat the payment selection process.

#### Cute Animal Picture

![Cute animal picture](http://1.bp.blogspot.com/-hlI1wKq1GOo/UCF9YQt8iyI/AAAAAAAABDU/IWZins_gTB0/s1600/red_panda_01.jpg)
