### PR TITLE
disable scope to lookup Event in management command

### DIFF
--- a/pretix_eth/management/commands/confirm_payments.py
+++ b/pretix_eth/management/commands/confirm_payments.py
@@ -187,7 +187,8 @@ class Command(BaseCommand):
         event_slug = options['event_slug']
         if event_slug is not None:
             try:
-                event = Event.objects.get(slug=event_slug)
+                with scope(organizer=None):
+                    event = Event.objects.get(slug=event_slug)
             except Event.DoesNotExist:
                 raise ValueError(f'Event with slug "{event_slug}" not found')
             payment_provider = Ethereum(event)


### PR DESCRIPTION
we cannot provide Organizer when running batch transaction

### What was wrong?

Management command `confirm_payments` was failing. We don't have an Organiser object for batch transaction there.

### How was it fixed?

There is a custom manager - scope - on the Event model. Do not use it when running a management command.

#### Cute Animal Picture

![Cute animal picture]()
