### PR TITLE
Eth validator

### DIFF
--- a/pretix_eth/static/pretix_eth/question-type.js
+++ b/pretix_eth/static/pretix_eth/question-type.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /*
  * payment_eth_html_add_question_type_javascript
@@ -23,7 +23,7 @@ function init() {
     walletconnect: {
       package: WalletConnectProvider,
       options: {
-        infuraId: "123456789b123456789" // Not a real id
+        infuraId: '123456789b123456789' // Not a real id
       }
     },
   };
@@ -48,7 +48,7 @@ async function onConnect(e) {
   try {
     provider = await web3Modal.connect();
   } catch(e) {
-    console.log("Could not get a wallet connection", e);
+    console.log('Could not get a wallet connection', e);
     return;
   }
   await refreshAccountData(e);
@@ -64,10 +64,12 @@ async function disconnect() {
 
 window.addEventListener('load', async () => {
   init();
-  const addressButtons = document.querySelectorAll(".btn-connect");
+  const addressButtons = document.querySelectorAll('.btn-connect');
   for (let i of addressButtons) {
     i.addEventListener('click', e => onConnect(e));
   }
+  const submitButton = document.querySelector('.btn-primary');
+  submitButton.addEventListener('click', checkValidity);
 });
 
 // from our marked fields obtain all ids of desired questions
@@ -82,6 +84,130 @@ function get_payment_eth_question_ids(class_name) {
     return payment_eth_question_ids;
 }
 
+function checkValidity() {
+  // Remove Input Warning DOM Nodes to avoid duplicate warnings
+  const warningElements = document.querySelectorAll('.alert-danger');
+  for (let i of warningElements) {
+    i.parentNode.removeChild(i);
+  }
+  // Create an array of Address Input values and evaluate
+  // Prevent form submission if validityState is false
+  const [...addressIds] = get_payment_eth_question_ids('payment_eth_info');
+  let addressInputValues = [];
+  for (let i of addressIds) {
+    let addressInputElements = document.querySelector(`input#${i}`);
+    addressInputValues.push(addressInputElements.value);
+  }
+  const validityState = isValidAddressInput(addressInputValues);
+  const submitButton = document.querySelector('.btn-primary');
+  if (validityState === false) {
+    submitButton.setAttribute('type', 'button');
+  } else {
+    submitButton.setAttribute('type', 'submit');
+  }
+}
+
+function createWarning(inputNo) {
+  const [...addressIds] = get_payment_eth_question_ids('payment_eth_info');
+  let firstIssue = true;
+  for (let i = 0; i < addressIds.length; i++) {
+    if (i === inputNo) {
+      let inputElement = document.querySelector(`input#${addressIds[i]}`);
+      let invalidInputWarning = document.createElement('div');
+      invalidInputWarning.classList.add('alert', 'alert-danger');
+      invalidInputWarning.setAttribute('role', 'alert');
+      invalidInputWarning.style.cssText = 'margin-top: 8px;';
+      invalidInputWarning.textContent = 'Invalid input. Please enter either a valid wallet address, or a valid ENS address.';
+      inputElement.parentNode.insertBefore(invalidInputWarning, inputElement.parentNode.lastChild);
+      if (firstIssue) {
+        invalidInputWarning.scrollIntoView({alignToTop: true, behavior: 'smooth'});
+        firstIssue = false;
+      }
+    }
+  }
+}
+
+function createDuplicateWarning() {
+  const [...addressIds] = get_payment_eth_question_ids('payment_eth_info');
+  let firstIssue = true;
+  let values = [];
+  for (let i of addressIds) {
+    const inputElement = document.querySelector(`#${i}`);
+    if (values.includes(inputElement.value)) {
+      let duplicateInputWarning = document.createElement('div');
+      duplicateInputWarning.classList.add('alert', 'alert-danger');
+      duplicateInputWarning.setAttribute('role', 'alert');
+      duplicateInputWarning.style.cssText = 'margin-top: 8px;';
+      duplicateInputWarning.textContent = 'Invalid input. We cannot send two NFTs to the same address. Please add a separate wallet address for each ticket.';
+      inputElement.parentNode.insertBefore(duplicateInputWarning, inputElement.parentNode.lastChild);
+      if (firstIssue) {
+        duplicateInputWarning.scrollIntoView({alignToTop: true, behavior: 'smooth'});
+        firstIssue = false;
+      }
+    } else {
+      values.push(inputElement.value);
+    }
+  }
+}
+
+function isValidAddressInput(inputs) {
+  let responses = [];
+  for (let input of inputs) {
+    if ((input !== '') && responses.includes(input)) {
+      createDuplicateWarning();
+      return false;
+    } else {
+      responses.push(input);
+    }
+  }
+  /* We evaluate a bool array instead of instantly returning for 2 reasons:
+   * 1. To avoid false positives
+   * 2. So we know which input value is invalid */
+  let validityChecks = [];
+  for (let response of responses) {
+    if (isBlank(response)) {
+      validityChecks.push(true);
+      break;
+    }
+    if (isEnsAddress(response)) {
+      validityChecks.push(true);
+    } else {
+      let web3 = new Web3(provider);
+      validityChecks.push(web3.utils.isAddress(response));
+    }
+  }
+  if (validityChecks.includes(false)) { 
+    for (let i = 0; i < validityChecks.length; i++) {
+      if (validityChecks[i] === false) {
+        createWarning(i);
+      }
+    }
+    return false;
+  } else {
+    return true;
+  }
+}
+
+function isBlank(str) {
+  return (str === '') ? true : false;
+}
+
+function isEnsAddress(address) {
+  const fourCharTld = ['.eth', '.xyz', '.art'];
+  const fiveCharTld = ['.luxe', '.kred', '.club'];
+  for (let i of fourCharTld) {
+    if (i === address.slice(address.length - 4)) {
+      return true;
+    }
+  }
+  for (let i of fiveCharTld) {
+    if (i === address.slice(address.length - 5)) {
+      return true;
+    }
+  }
+  return false;
+}
+>>>>>>> Form validation logic implemented
 
 $(function () {
   // Detect useragent, and disable button if Firefox
@@ -90,21 +216,21 @@ $(function () {
   // Get unique Ids
   const [...targetElements] = get_payment_eth_question_ids('payment_eth_info');
 
-
   // Add Button Elements or Firefox Warning Text
   for (let i of targetElements) {
     // Button Element
     let el = document.querySelector(`#${i}`);
-    let addressButton = document.createElement("button");
+    let addressButton = document.createElement('button');
     addressButton.setAttribute('type', 'button');
-    addressButton.textContent = "Add Wallet Address";
+    addressButton.textContent = 'Add Wallet Address';
     addressButton.id = i;
-    addressButton.classList.add("btn", "btn-connect", "btn-block", "btn-primary", "btn-lg");
-    addressButton.style.cssText = "max-width: 360px; margin-top: 8px;";
-    // Warning Text Element
-    let warningText = document.createElement("p");
-    warningText.appendChild(document.createTextNode("Unfortunately the web3 API we use to automatically add a wallet address is not supported in Firefox at this time. Please carefully copy and paste your wallet address into the above field."));
-    warningText.style.cssText = "margin-top: 8px;";
+    addressButton.classList.add('btn', 'btn-connect', 'btn-block', 'btn-lg');
+    addressButton.style.cssText = 'max-width: 360px; margin-top: 8px; background: #8e44b3; border-color: #8e44b3; color: white;';
+
+    // Firefox Warning Text Element
+    let warningText = document.createElement('p');
+    warningText.appendChild(document.createTextNode('Unfortunately the web3 API we use to automatically add a wallet address is not supported in Firefox at this time. Please carefully copy and paste your wallet address into the above field.'));
+    warningText.style.cssText = 'margin-top: 8px;';
 
     // Insert Node
     if (isBrowserFirefox === -1) {

--- a/pretix_eth/static/pretix_eth/question-type.js
+++ b/pretix_eth/static/pretix_eth/question-type.js
@@ -207,7 +207,6 @@ function isEnsAddress(address) {
   }
   return false;
 }
->>>>>>> Form validation logic implemented
 
 $(function () {
   // Detect useragent, and disable button if Firefox

--- a/pretix_eth/static/pretix_eth/question-type.js
+++ b/pretix_eth/static/pretix_eth/question-type.js
@@ -231,11 +231,13 @@ $(function () {
     warningText.appendChild(document.createTextNode('Unfortunately the web3 API we use to automatically add a wallet address is not supported in Firefox at this time. Please carefully copy and paste your wallet address into the above field.'));
     warningText.style.cssText = 'margin-top: 8px;';
 
-    // Insert Node
-    if (isBrowserFirefox === -1) {
-      el.parentNode.append(addressButton);
-    } else {
-      el.parentNode.append(warningText);
+    // Insert DOM node if it exists
+    if (el) {
+      if (isBrowserFirefox === -1) {
+        el.parentNode.append(addressButton);
+      } else {
+        el.parentNode.append(warningText);
+      }
     }
   }
 });

--- a/pretix_eth/static/pretix_eth/question-type.js
+++ b/pretix_eth/static/pretix_eth/question-type.js
@@ -120,7 +120,7 @@ function createWarning(inputNo) {
       invalidInputWarning.textContent = 'Invalid input. Please enter either a valid wallet address, or a valid ENS address.';
       inputElement.parentNode.insertBefore(invalidInputWarning, inputElement.parentNode.lastChild);
       if (firstIssue) {
-        invalidInputWarning.scrollIntoView({alignToTop: true, behavior: 'smooth'});
+        inputElement.scrollIntoView({alignToTop: true, behavior: 'smooth'});
         firstIssue = false;
       }
     }
@@ -141,7 +141,7 @@ function createDuplicateWarning() {
       duplicateInputWarning.textContent = 'Invalid input. We cannot send two NFTs to the same address. Please add a separate wallet address for each ticket.';
       inputElement.parentNode.insertBefore(duplicateInputWarning, inputElement.parentNode.lastChild);
       if (firstIssue) {
-        duplicateInputWarning.scrollIntoView({alignToTop: true, behavior: 'smooth'});
+        inputElement.scrollIntoView({alignToTop: true, behavior: 'smooth'});
         firstIssue = false;
       }
     } else {


### PR DESCRIPTION
### What was wrong?

User could input anything for a wallet address.

### How was it fixed?

Follows specifications laid out in discussion of issue #101. Specifically, it accepts valid wallet address or ens address. If the user inputs invalid entries, when the user tries to submit the data  the submit button's type is changed from `submit` to `button` (i.e. they cannot perform the submit action), an event is triggered that scrolls to the first input element with an invalid entry, and some warning text is displayed below every input with an issue. When the issues are resolved the submit button's type is returned to `submit`.

One issue I noticed though is the validation can get into a weird state if a user clicks the "Copy info" button. Since I don't think there is a use case for that button as we are using it (name associated with ticket and wallet address will always be different individuals/unique address), I think we should disable this button. If there is a potential use case for it though, then some additional work will need to be done.

Also, my understanding is it should be okay to leave the address input blank, so the JS validation logic accepts that, but currently on the backend this is a required field, so this should be resolved as well.