### PR TITLE
Don't skip payment confirmation for unexpected payment types

### DIFF
--- a/pretix_eth/management/commands/confirm_payments.py
+++ b/pretix_eth/management/commands/confirm_payments.py
@@ -88,18 +88,18 @@ class Command(BaseCommand):
 
                 if expected_currency_type == 'ETH':
                     if token_amount > 0:
-                        logger.warning(f'  * Found unexpected token payment of {token_amount}')
+                        logger.warning(f'  * Found unexpected payment of {token_amount} DAI')
                     if eth_amount < expected_amount:
-                        logger.warning(f'  * Expected payment of at least {expected_amount} {expected_currency_type}')  # noqa: E501
-                        logger.warning(f'  * Given payment was only for {eth_amount}')
+                        logger.warning(f'  * Expected payment of at least {expected_amount} ETH')  # noqa: E501
+                        logger.warning(f'  * Given payment was {eth_amount} ETH')  # noqa: E501
                         logger.warning(f'  * Skipping')
                         continue
                 elif expected_currency_type == 'DAI':
                     if eth_amount > 0:
-                        logger.warning(f'  * Found unexpected ETH payment of {eth_amount}')
+                        logger.warning(f'  * Found unexpected payment of {eth_amount} ETH')
                     if token_amount < expected_amount:
-                        logger.warning(f'  * Expected payment of at least {expected_amount} {expected_currency_type}')  # noqa: E501
-                        logger.warning(f'  * Given payment was only for {token_amount}')
+                        logger.warning(f'  * Expected payment of at least {expected_amount} DAI')  # noqa: E501
+                        logger.warning(f'  * Given payment was {token_amount} DAI')  # noqa: E501
                         logger.warning(f'  * Skipping')
                         continue
 

--- a/pretix_eth/management/commands/confirm_payments.py
+++ b/pretix_eth/management/commands/confirm_payments.py
@@ -89,8 +89,6 @@ class Command(BaseCommand):
                 if expected_currency_type == 'ETH':
                     if token_amount > 0:
                         logger.warning(f'  * Found unexpected token payment of {token_amount}')
-                        logger.warning(f'  * Skipping')
-                        continue
                     if eth_amount < expected_amount:
                         logger.warning(f'  * Expected payment of at least {expected_amount} {expected_currency_type}')  # noqa: E501
                         logger.warning(f'  * Given payment was only for {eth_amount}')
@@ -99,8 +97,6 @@ class Command(BaseCommand):
                 elif expected_currency_type == 'DAI':
                     if eth_amount > 0:
                         logger.warning(f'  * Found unexpected ETH payment of {eth_amount}')
-                        logger.warning(f'  * Skipping')
-                        continue
                     if token_amount < expected_amount:
                         logger.warning(f'  * Expected payment of at least {expected_amount} {expected_currency_type}')  # noqa: E501
                         logger.warning(f'  * Given payment was only for {token_amount}')

--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -203,7 +203,6 @@ class Ethereum(BasePaymentProvider):
 
         web3modal_url = f'https://checkout.web3modal.com/?currency={currency_type}&amount={amount_in_ether_or_dai}&to={wallet_address}'  # noqa: E501
 
-
         ctx.update({
             'erc_681_url': erc_681_url,
             'uniswap_url': uniswap_url,


### PR DESCRIPTION
### What was wrong?

We decided that we shouldn't skip payment confirmation if unexpected payments are found for the wrong currency type but an adequate payment *is* found for the correct currency type.

Made modifications to fix this.  Also updated some of the logging message wording to be a bit more clear.