### PR TITLE
Fixed web socket CSP error in Chrome

### DIFF
--- a/pretix_eth/forms.py
+++ b/pretix_eth/forms.py
@@ -22,8 +22,8 @@ class WalletAddressTxtFile(ExtFileField):
 
             # Strip leading and trailing whitespace on each line; filter empty
             # lines; filter comments
-            lines = [l.strip() for l in lines if l.strip()]
-            lines = [l for l in lines if not COMMENT_RE.match(l)]
+            lines = [line.strip() for line in lines if line.strip()]
+            lines = [line for line in lines if not COMMENT_RE.match(line)]
 
             if len(lines) == 0:
                 raise forms.ValidationError(_("File contains no addresses"))

--- a/pretix_eth/management/commands/confirm_payments.py
+++ b/pretix_eth/management/commands/confirm_payments.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                     if eth_amount < expected_amount:
                         logger.warning(f'  * Expected payment of at least {expected_amount} ETH')  # noqa: E501
                         logger.warning(f'  * Given payment was {eth_amount} ETH')  # noqa: E501
-                        logger.warning(f'  * Skipping')
+                        logger.warning(f'  * Skipping')  # noqa: F541
                         continue
                 elif expected_currency_type == 'DAI':
                     if eth_amount > 0:
@@ -100,7 +100,7 @@ class Command(BaseCommand):
                     if token_amount < expected_amount:
                         logger.warning(f'  * Expected payment of at least {expected_amount} DAI')  # noqa: E501
                         logger.warning(f'  * Given payment was {token_amount} DAI')  # noqa: E501
-                        logger.warning(f'  * Skipping')
+                        logger.warning(f'  * Skipping')  # noqa: F541
                         continue
 
                 if no_dry_run:

--- a/pretix_eth/signals.py
+++ b/pretix_eth/signals.py
@@ -31,6 +31,7 @@ def signal_process_response(sender, request, response, **kwargs):
             "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
             "'sha256-O+AX3tWIOimhuzg+lrMfltcdtWo7Mp2Y9qJUkE6ysWE='",
         ],
+        # Chrome correctly errors out without this CSP
         'connect-src': [
             "wss://bridge.walletconnect.org/",
         ],

--- a/pretix_eth/signals.py
+++ b/pretix_eth/signals.py
@@ -31,6 +31,9 @@ def signal_process_response(sender, request, response, **kwargs):
             "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
             "'sha256-O+AX3tWIOimhuzg+lrMfltcdtWo7Mp2Y9qJUkE6ysWE='",
         ],
+        'connect-src': [
+            "wss://bridge.walletconnect.org/",
+        ],
         'manifest-src': ["'self'"],
     })
     response['Content-Security-Policy'] = _render_csp(h)


### PR DESCRIPTION
### What was wrong?

In Chrome, there is a CSP error with wallet connect (issue #109). 

### How was it fixed?

We added the secure web socket address to our connect-src CSP header.

#### Cute Animal Picture

![capybaras](https://user-images.githubusercontent.com/18646852/83444934-fd9b7380-a400-11ea-8008-91afa1f87ecf.jpg)
