### PR TITLE
Annotations

### DIFF
--- a/pretix_eth/models.py
+++ b/pretix_eth/models.py
@@ -30,7 +30,7 @@ class WalletAddressManager(models.Manager):
     def get_queryset(self) -> models.QuerySet:
         return WalletAddressQuerySet(self.model, using=self._db)
 
-    def get_for_order_payment(self, order_payment: OrderPayment):
+    def get_for_order_payment(self, order_payment: OrderPayment) -> WalletAddress:
         event = order_payment.order.event
         unused_addresses = self.select_for_update().unused().for_event(event)
 

--- a/pretix_eth/models.py
+++ b/pretix_eth/models.py
@@ -30,7 +30,7 @@ class WalletAddressManager(models.Manager):
     def get_queryset(self) -> models.QuerySet:
         return WalletAddressQuerySet(self.model, using=self._db)
 
-    def get_for_order_payment(self, order_payment: OrderPayment) -> WalletAddress:
+    def get_for_order_payment(self, order_payment: OrderPayment) -> 'WalletAddress':
         event = order_payment.order.event
         unused_addresses = self.select_for_update().unused().for_event(event)
 


### PR DESCRIPTION
### What was wrong?

Annotations were removed because py3.6 does not support deferred annotations via `__future__`.

### How was it fixed?

Maybe a string instead of an actual object will work. See #114 discussion.