### PR TITLE
Signal that refunds are supported

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -238,7 +238,7 @@ class Ethereum(BasePaymentProvider):
         wallet_queryset = WalletAddress.objects.filter(order_payment=refund.payment)
 
         if wallet_queryset.count() != 1:
-            raise ValueError('There is not assigned wallet address to this payment')
+            raise Exception('Invariant: There is not assigned wallet address to this payment')
 
         refund.info_data = {
             'currency_type': refund.payment.info_data['currency_type'],

--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -233,12 +233,12 @@ class Ethereum(BasePaymentProvider):
 
     def execute_refund(self, refund: OrderRefund):
         if refund.payment is None:
-            raise ValueError("There is no associated payment with this refund")
+            raise Exception('Invariant: No payment associated with refund')
 
         wallet_queryset = WalletAddress.objects.filter(order_payment=refund.payment)
 
         if wallet_queryset.count() != 1:
-            raise ValueError("There is not assigned wallet address to this payment")
+            raise ValueError('There is not assigned wallet address to this payment')
 
         refund.info_data = {
             'currency_type': refund.payment.info_data['currency_type'],

--- a/tests/core/test_refund.py
+++ b/tests/core/test_refund.py
@@ -49,28 +49,3 @@ def test_refund_created(event, organizer, create_admin_client, get_organizer_sco
             'amount': '100',
             'wallet_address': '0x0000000000000000000000000000000000000001',
         }
-
-
-@pytest.mark.django_db
-def test_invalid_refund_no_wallet(event, organizer, create_admin_client, get_order_and_payment):
-    assert not OrderRefund.objects.exists()
-
-    order, payment = get_order_and_payment(
-        payment_kwargs={'state': OrderPayment.PAYMENT_STATE_CONFIRMED, 'provider': 'ethereum'},
-        info_data={'amount': '100', 'currency_type': 'ETH'}
-    )
-
-    url = reverse('control:event.order.refunds.start', kwargs={
-        'event': event.slug,
-        'organizer': organizer.slug,
-        'code': order.code
-    })
-
-    client = create_admin_client(event)
-
-    with pytest.raises(ValueError, match='There is not assigned wallet address to this payment'):
-        client.post(url, {
-            f'refund-{payment.id}': '100',
-            'start-mode': 'full',
-            'perform': True
-        })

--- a/tests/core/test_refund.py
+++ b/tests/core/test_refund.py
@@ -6,6 +6,7 @@ from pretix.base.models import (
 )
 
 from pretix_eth.models import WalletAddress
+from django.urls import reverse
 
 
 @pytest.mark.django_db
@@ -22,7 +23,12 @@ def test_refund_created(event, organizer, create_admin_client, get_organizer_sco
                                  hex_address='0x0000000000000000000000000000000000000001')
     WalletAddress.objects.get_for_order_payment(payment)
 
-    url = f'/control/event/{organizer.slug}/{event.slug}/orders/{order.code}/refund'
+    url = reverse('control:event.order.refunds.start', kwargs={
+        'event': event.slug,
+        'organizer': organizer.slug,
+        'code': order.code
+    })
+
     client = create_admin_client(event)
     response = client.post(url, {
         f'refund-{payment.id}': '100',
@@ -54,7 +60,12 @@ def test_invalid_refund_no_wallet(event, organizer, create_admin_client, get_ord
         info_data={'amount': '100', 'currency_type': 'ETH'}
     )
 
-    url = f'/control/event/{organizer.slug}/{event.slug}/orders/{order.code}/refund'
+    url = reverse('control:event.order.refunds.start', kwargs={
+        'event': event.slug,
+        'organizer': organizer.slug,
+        'code': order.code
+    })
+
     client = create_admin_client(event)
 
     with pytest.raises(ValueError, match='There is not assigned wallet address to this payment'):

--- a/tests/core/test_refund.py
+++ b/tests/core/test_refund.py
@@ -1,0 +1,65 @@
+import pytest
+
+from pretix.base.models import (
+    OrderRefund,
+    OrderPayment,
+)
+
+from pretix_eth.models import WalletAddress
+
+
+@pytest.mark.django_db
+def test_refund_created(event, organizer, create_admin_client, get_organizer_scope,
+                        get_order_and_payment):
+    assert not OrderRefund.objects.exists()
+
+    order, payment = get_order_and_payment(
+        payment_kwargs={'state': OrderPayment.PAYMENT_STATE_CONFIRMED, 'provider': 'ethereum'},
+        info_data={'amount': '100', 'currency_type': 'ETH'}
+    )
+
+    WalletAddress.objects.create(event=event,
+                                 hex_address='0x0000000000000000000000000000000000000001')
+    WalletAddress.objects.get_for_order_payment(payment)
+
+    url = f'/control/event/{organizer.slug}/{event.slug}/orders/{order.code}/refund'
+    client = create_admin_client(event)
+    response = client.post(url, {
+        f'refund-{payment.id}': '100',
+        'start-mode': 'full',
+        'perform': True
+    })
+
+    assert response.status_code == 302
+
+    with get_organizer_scope():
+        assert OrderRefund.objects.exists()
+        assert OrderRefund.objects.count() == 1
+        refund = OrderRefund.objects.first()
+        assert refund.payment == payment
+        assert refund.state == OrderRefund.REFUND_STATE_CREATED
+        assert refund.info_data == {
+            'currency_type': 'ETH',
+            'amount': '100',
+            'wallet_address': '0x0000000000000000000000000000000000000001',
+        }
+
+
+@pytest.mark.django_db
+def test_invalid_refund_no_wallet(event, organizer, create_admin_client, get_order_and_payment):
+    assert not OrderRefund.objects.exists()
+
+    order, payment = get_order_and_payment(
+        payment_kwargs={'state': OrderPayment.PAYMENT_STATE_CONFIRMED, 'provider': 'ethereum'},
+        info_data={'amount': '100', 'currency_type': 'ETH'}
+    )
+
+    url = f'/control/event/{organizer.slug}/{event.slug}/orders/{order.code}/refund'
+    client = create_admin_client(event)
+
+    with pytest.raises(ValueError, match='There is not assigned wallet address to this payment'):
+        client.post(url, {
+            f'refund-{payment.id}': '100',
+            'start-mode': 'full',
+            'perform': True
+        })


### PR DESCRIPTION
### What was wrong?

There is no support for automatic refunds. #121 

### How was it fixed?

Plugin signals that it supports automatic refunds, and stores data that is needed for the refund.

Autimatic confirmation for refunds is not yet implemented, but created refunds can be manually confirmed by organizer. 

#### Cute Animal Picture

![Cute animal picture](https://static4.depositphotos.com/1000291/324/i/600/depositphotos_3242253-stock-photo-siberian-husky-dog-puppy.jpg)
