### PR TITLE
Payment and refund data exporter

### DIFF
--- a/pretix_eth/exporter.py
+++ b/pretix_eth/exporter.py
@@ -1,0 +1,152 @@
+from collections import OrderedDict
+
+from django import forms
+
+from pretix.base.exporter import ListExporter
+from pretix.base.models import (
+    OrderPayment,
+    OrderRefund,
+)
+from pretix_eth.models import WalletAddress
+
+import pytz
+
+
+def date_to_string(time_zone, date):
+    return date.astimezone(time_zone).date().strftime('%Y-%m-%d')
+
+
+def payment_to_row(payment):
+    time_zone = pytz.timezone(payment.order.event.settings.timezone)
+    if payment.payment_date:
+        completion_date = date_to_string(time_zone, payment.payment_date)
+    else:
+        completion_date = ''
+
+    if payment.info_data['currency_type']:
+        token = payment.info_data['currency_type']
+    else:
+        token = ''
+
+    if WalletAddress.objects.filter(order_payment=payment).first():
+        wallet_address = WalletAddress.objects.filter(
+            order_payment=payment).first().hex_address
+    else:
+        wallet_address = ''
+
+    row = [
+        'Payment',
+        payment.order.event.slug,
+        payment.order.code,
+        payment.full_id,
+        date_to_string(time_zone, payment.created),
+        completion_date,
+        payment.state,
+        payment.amount,
+        token,
+        wallet_address
+    ]
+    return row
+
+
+def refund_to_row(refund):
+    time_zone = pytz.timezone(refund.order.event.settings.timezone)
+    if refund.execution_date:
+        completion_date = date_to_string(time_zone, refund.execution_date)
+    else:
+        completion_date = ''
+
+    if refund.payment.info_data['currency_type']:
+        token = refund.payment.info_data['currency_type']
+    else:
+        token = ''
+
+    if WalletAddress.objects.filter(order_payment=refund.payment).first():
+        wallet_address = WalletAddress.objects.filter(
+            order_payment=refund.payment).first().hex_address
+    else:
+        wallet_address = ''
+
+    row = [
+        'Refund',
+        refund.order.event.slug,
+        refund.order.code,
+        refund.full_id,
+        date_to_string(time_zone, refund.created),
+        completion_date,
+        refund.state,
+        refund.amount,
+        token,
+        wallet_address
+    ]
+    return row
+
+
+class EthereumOrdersExporter(ListExporter):
+    identifier = 'ethorders'
+    verbose_name = 'Ethereum orders and refunds'
+
+    headers = (
+        'Type', 'Event slug', 'Order', 'Payment ID', 'Creation date',
+        'Completion date', 'Status', 'Amount', 'Token', 'Wallet address'
+    )
+
+    @property
+    def additional_form_fields(self):
+        return OrderedDict(
+            [
+                ('payment_states',
+                 forms.MultipleChoiceField(
+                     label='Payment states',
+                     choices=OrderPayment.PAYMENT_STATES,
+                     initial=[OrderPayment.PAYMENT_STATE_CONFIRMED,
+                              OrderPayment.PAYMENT_STATE_REFUNDED],
+                     widget=forms.CheckboxSelectMultiple,
+                     required=False
+                 )),
+                ('refund_states',
+                 forms.MultipleChoiceField(
+                     label='Refund states',
+                     choices=OrderRefund.REFUND_STATES,
+                     initial=[OrderRefund.REFUND_STATE_DONE, OrderRefund.REFUND_STATE_CREATED,
+                              OrderRefund.REFUND_STATE_TRANSIT],
+                     widget=forms.CheckboxSelectMultiple,
+                     required=False
+                 )),
+            ]
+        )
+
+    def iterate_list(self, form_data):
+        payments = OrderPayment.objects.filter(
+            order__event__in=self.events,
+            state__in=form_data.get('payment_states', []),
+            provider='ethereum'
+        ).order_by('created')
+
+        refunds = OrderRefund.objects.filter(
+            order__event__in=self.events,
+            state__in=form_data.get('refund_states', []),
+            provider='ethereum'
+        ).order_by('created')
+
+        objs = sorted(list(payments) + list(refunds), key=lambda obj: obj.created)
+
+        yield self.headers
+
+        yield self.ProgressSetTotal(total=len(objs))
+        for obj in objs:
+            if isinstance(obj, OrderPayment):
+                row = payment_to_row(obj)
+            elif isinstance(obj, OrderRefund):
+                row = refund_to_row(obj)
+            else:
+                raise Exception(
+                    'Invariant:Expected OrderPayment or OrderRefund, found {0}'.format((obj))
+                )
+            yield row
+
+    def get_filename(self):
+        if self.is_multievent:
+            return '{}_payments'.format(self.events.first().organizer.slug)
+        else:
+            return '{}_payments'.format(self.event.slug)

--- a/pretix_eth/signals.py
+++ b/pretix_eth/signals.py
@@ -10,8 +10,14 @@ from pretix.presale.signals import (
     question_form_fields,
     process_response,
 )
-from pretix.base.signals import logentry_display, register_payment_providers
+from pretix.base.signals import (
+    logentry_display,
+    register_payment_providers,
+    register_data_exporters,
+)
+
 from pretix.control.signals import nav_event_settings
+from .exporter import EthereumOrdersExporter
 
 
 NFT_QUESTION_IDENTIFIER = 'eth-payment-plugin-nft-address'
@@ -109,3 +115,8 @@ def wallet_address_upload_logentry_display(sender, logentry, **kwargs):
             new_address_count=data['new_address_count'],
             existing_address_count=data['existing_address_count'],
         )
+
+
+@receiver(register_data_exporters, dispatch_uid='single_event_eth_orders')
+def register_data_exporter(sender, **kwargs):
+    return EthereumOrdersExporter

--- a/tests/core/test_payment_and_refund_export.py
+++ b/tests/core/test_payment_and_refund_export.py
@@ -1,0 +1,133 @@
+import pytest
+from django.urls import reverse
+
+from pretix.base.models import (
+    OrderPayment,
+    OrderRefund,
+)
+
+from pretix_eth.models import WalletAddress
+
+
+@pytest.mark.django_db
+def test_headers_are_present(organizer, event, create_admin_client):
+    expected_headers = ['Type', 'Event slug', 'Order', 'Payment ID', 'Creation date',
+                        'Completion date', 'Status', 'Amount', 'Token', 'Wallet address']
+
+    admin_clinet = create_admin_client(event)
+
+    url = reverse('control:event.orders.export.do', kwargs={
+        'event': event.slug,
+        'organizer': organizer.slug
+    })
+
+    response = admin_clinet.post(url, {
+        'exporter': 'ethorders',
+        'ethorders-_format': 'default'
+    }, follow=True)
+
+    assert response.status_code == 200
+
+    file_content = ''.join(str(row) for row in response.streaming_content)
+
+    for header in expected_headers:
+        assert header in file_content
+
+
+@pytest.fixture
+def create_payment_with_address(get_order_and_payment, event, provider):
+    def _create_payment_with_address(
+            payment_kwargs={
+                'state': OrderPayment.PAYMENT_STATE_CONFIRMED,
+                'amount': '100.0',
+                'provider': 'ethereum'
+            },
+            info_data={
+                'currency_type': 'ETH',
+                'amount': '100.0'
+            },
+            hex_address='0x0000000000000000000000000000000000000000'):
+
+        _, payment = get_order_and_payment(payment_kwargs=payment_kwargs, info_data=info_data)
+
+        WalletAddress.objects.create(
+            event=event,
+            hex_address=hex_address
+        )
+        WalletAddress.objects.get_for_order_payment(payment)
+
+        return payment
+    return _create_payment_with_address
+
+
+@pytest.mark.django_db
+def test_payment_data_present(organizer, event, create_admin_client, create_payment_with_address):
+    assert not OrderPayment.objects.exists()
+
+    create_payment_with_address()
+
+    assert OrderPayment.objects.exists()
+
+    admin_clinet = create_admin_client(event)
+
+    url = reverse('control:event.orders.export.do', kwargs={
+        'event': event.slug,
+        'organizer': organizer.slug
+    })
+
+    response = admin_clinet.post(url, {
+        'exporter': 'ethorders',
+        'ethorders-_format': 'default',
+        'ethorders-payment_states': 'confirmed'
+    }, follow=True)
+
+    assert response.status_code == 200
+
+    file_content = ''.join(str(row) for row in response.streaming_content)
+
+    assert '0x0000000000000000000000000000000000000000' in file_content
+    assert 'ETH' in file_content
+    assert 'Payment' in file_content
+    assert '100.0' in file_content
+
+
+@pytest.mark.django_db
+def test_refund_data_present(organizer, event, create_admin_client,
+                             create_payment_with_address, provider, get_organizer_scope):
+    assert not OrderRefund.objects.exists()
+
+    payment = create_payment_with_address()
+
+    with get_organizer_scope():
+        refund = payment.order.refunds.create(
+            payment=payment,
+            source=OrderRefund.REFUND_SOURCE_ADMIN,
+            state=OrderRefund.REFUND_STATE_CREATED,
+            amount=payment.amount,
+            provider='ethereum'
+        )
+    provider.execute_refund(refund)
+
+    assert OrderRefund.objects.exists()
+
+    admin_clinet = create_admin_client(event)
+
+    url = reverse('control:event.orders.export.do', kwargs={
+        'event': event.slug,
+        'organizer': organizer.slug
+    })
+
+    response = admin_clinet.post(url, {
+        'exporter': 'ethorders',
+        'ethorders-_format': 'default',
+        'ethorders-refund_states': 'created'
+    }, follow=True)
+
+    assert response.status_code == 200
+
+    file_content = ''.join(str(row) for row in response.streaming_content)
+
+    assert 'Refund' in file_content
+    assert 'ETH' in file_content
+    assert '0x0000000000000000000000000000000000000000' in file_content
+    assert '100.0' in file_content


### PR DESCRIPTION
### What was wrong?

Pretix has a built-in payment and refund data exporter. However, it does not export essential data like wallet address, currency, etc. Also, to the best of my knowledge, there is no way of appending these data to the existing exporter. 

Related to #121 #84 

### How was it fixed?

This PR implements a data exporter that contains data like wallet address, currency, etc.

#### Cute Animal Picture

![Cute animal picture](https://images.ctfassets.net/f60q1anpxzid/asset-2ee2e43d43b93957a549a3d944297d31/687205eca7d573393bea77d53b2377e5/cute-dog-names-1280.jpg?fm=jpg&fl=progressive&q=50&w=1200)
