### PR TITLE
Cryptography version fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     author_email='pretix-eth-payment-plugin@ethereum.org',
     license='Apache Software License',
     install_requires=[
+        "cryptography==3.3.1"
         "pretix>=3.8.0",
         "web3>=5.7.0",
         "eth-abi>=2.1.1,<3",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     author_email='pretix-eth-payment-plugin@ethereum.org',
     license='Apache Software License',
     install_requires=[
-        "cryptography==3.3.1"
+        "cryptography==3.3.1",
         "pretix>=3.8.0",
         "web3>=5.7.0",
         "eth-abi>=2.1.1,<3",


### PR DESCRIPTION
### What was wrong?

The new version of Cryptography breaks the setup for pretix. Related to #136. 

### How was it fixed?

This is a temporary solution until the newer version of pretix will be released. 

#### Cute Animal Picture

![Cute animal picture](https://media.nbcwashington.com/2019/09/GettyImages-594744690.jpg?fit=1200%2C675)
