### PR TITLE
Updates test for confirm_payments command

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,10 +199,10 @@ def django_db_setup(
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--web3", action="store_true", default=False,
+        "--require-web3", action="store_true", default=False,
         help="run integration tests that need web3 provider",
     )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "web3: mark test as one that requires web3 provider")
+    config.addinivalue_line("markers", "require-web3: mark test as one that requires web3 provider")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,3 +195,14 @@ def django_db_setup(
 
     if not django_db_keepdb:
         request.addfinalizer(teardown_database)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--web3", action="store_true", default=False,
+        help="run integration tests that need web3 provider",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "web3: mark test as one that requires web3 provider")

--- a/tests/integration/test_confirm_payments.py
+++ b/tests/integration/test_confirm_payments.py
@@ -10,13 +10,18 @@ from pretix_eth.models import WalletAddress
 
 
 WEB3_PROVIDER_URI = os.environ.get('WEB3_PROVIDER_URI')
-skip_if_no_web3_provider = pytest.mark.skipif(
-    WEB3_PROVIDER_URI is None,
-    reason='Web3 provider uri is not set',
-)
-
-
 ROPSTEN_DAI_ADDRESS = "0xaD6D458402F60fD3Bd25163575031ACDce07538D"
+
+
+def check_web3_provider(pytesconfig):
+    __tracebackhide__ = True
+    if not pytesconfig.getoption("--web3"):
+        pytest.skip(
+            '--web3 flag is not set')
+
+    if WEB3_PROVIDER_URI is None:
+        pytest.fail(
+            '--web3 flag is set, but WEB3_PROVIDER_URI is None')
 
 
 @pytest.fixture
@@ -59,12 +64,13 @@ TEST_ENOUGH_AMOUNT = [
 ]
 
 
-@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payment_enough(provider, event, get_request_order_payment):
+def test_confirm_payment_enough(provider, event, get_request_order_payment, pytestconfig):
+    check_web3_provider(pytestconfig)
+
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
@@ -95,12 +101,13 @@ def test_confirm_payment_enough(provider, event, get_request_order_payment):
         assert payment.state == payment.PAYMENT_STATE_CONFIRMED
 
 
-@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payment_dry_run(provider, event, get_request_order_payment):
+def test_confirm_payment_dry_run(provider, event, get_request_order_payment, pytestconfig):
+    check_web3_provider(pytestconfig)
+
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
@@ -138,12 +145,13 @@ TEST_LOWER_AMOUNT = [
 ]
 
 
-@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payment_lower_amount(provider, event, get_request_order_payment):
+def test_confirm_payment_lower_amount(provider, event, get_request_order_payment, pytestconfig):
+    check_web3_provider(pytestconfig)
+
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
@@ -182,12 +190,13 @@ TEST_WRONG_CURRENCY = [
 ]
 
 
-@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payment_wrong_currency(provider, event, get_request_order_payment):
+def test_confirm_payment_wrong_currency(provider, event, get_request_order_payment, pytestconfig):
+    check_web3_provider(pytestconfig)
+
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 

--- a/tests/integration/test_confirm_payments.py
+++ b/tests/integration/test_confirm_payments.py
@@ -2,206 +2,189 @@ import os
 
 from django.core.management import call_command
 import pytest
+import time
 
-ETHERSCAN_API_KEY = os.environ.get('ETHERSCAN_API_KEY')
-skip_if_no_etherscan_api_key = pytest.mark.skipif(
-    ETHERSCAN_API_KEY is None,
-    reason='Etherscan api key is not set',
+from django.test import RequestFactory
+
+from pretix_eth.models import WalletAddress
+
+
+WEB3_PROVIDER_URI = 'wss://ropsten.infura.io/ws/v3/7c8da79a6f0e4485be91055385dbcd38'
+skip_if_no_web3_provider = pytest.mark.skipif(
+    WEB3_PROVIDER_URI is None,
+    reason='Web3 provider uri is not set',
 )
 
-# Fake DAI deployment (LAI token)
-GOERLI_TOKEN_ADDRESS = '0x57865b333088b4369c77e11b8c0f410ca2242e09'
-GOERLI_WALLET_ADDRESS = '0xddd41b99968179d5f08b93a45eee20108c1b3f95'
+
+ROPSTEN_DAI_ADDRESS = "0xaD6D458402F60fD3Bd25163575031ACDce07538D"
 
 
 @pytest.fixture
-def get_orders_and_payments(get_order_and_payment):
-    def _get_orders_and_payments(info_data_list):
-        orders = []
-        payments = []
+def get_request_order_payment(get_order_and_payment):
+    def _create_request_and_payment(order_kwargs=None, payment_kwargs=None, info_data=None):
+        order, payment = get_order_and_payment(order_kwargs=order_kwargs,
+                                               payment_kwargs=payment_kwargs,
+                                               info_data=info_data)
+        factory = RequestFactory()
+        request = factory.get('/checkout')
 
-        for info_data in info_data_list:
-            order, payment = get_order_and_payment(info_data=info_data)
-
-            orders.append(order)
-            payments.append(payment)
-
-        return orders, payments
-
-    return _get_orders_and_payments
+        return request, order, payment
+    return _create_request_and_payment
 
 
-TEST_EQUAL_PAYMENTS = [
-    {'currency_type': 'ETH', 'amount': int('000100000000000001', base=10)},
-    {'currency_type': 'ETH', 'amount': int('000200000000000002', base=10)},
-    {'currency_type': 'ETH', 'amount': int('001000000000000003', base=10)},  # Internal
-    {'currency_type': 'ETH', 'amount': int('000100000000000004', base=10)},  # Internal
-    {'currency_type': 'ETH', 'amount': int('000500000000000005', base=10)},
-    {'currency_type': 'DAI', 'amount': int('100000000000000006', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('200000000000000007', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('300000000000000008', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('400000000000000009', base=10)},  # LAI token
+def make_order_payment(payment_info, provider, get_request_order_payment):
+    order_kwargs = {
+        'total': payment_info['amount']
+    }
+    payment_kwargs = {
+        'amount': payment_info['amount']
+    }
+    info_data = {
+        'currency_type': payment_info['currency'],
+        'time': int(time.time()),
+        'amount': payment_info['amount']
+    }
+    request, order, payment = get_request_order_payment(
+        order_kwargs=order_kwargs, payment_kwargs=payment_kwargs, info_data=info_data)
+    provider.payment_pending_render(request, payment)
+
+    return order, payment
+
+
+TEST_ENOUGH_AMOUNT = [
+    {'currency': 'ETH', 'amount': int('1000', base=10),
+     'hex_address': '0xb84AC43014d60AE5dCe5d36975eE461f31e953d3'},  # Has about 0.5 ETH
+    {'currency': 'DAI', 'amount': int('1000', base=10),
+     'hex_address': '0x18FF3A11FAF05F83198A8724006975ce414872Bc'}   # Has about 48 DAI
 ]
 
 
-@skip_if_no_etherscan_api_key
+@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payments_works_for_equal_amounts(get_orders_and_payments):
-    orders, payments = get_orders_and_payments(TEST_EQUAL_PAYMENTS)
+def test_confirm_payment_enough(provider, event, get_request_order_payment):
+    provider.settings.set('ETH_RATE', '0.001')
+    provider.settings.set('DAI_RATE', '1.0')
 
-    call_command(
-        'confirm_payments',
-        '--wallet-address', GOERLI_WALLET_ADDRESS,
-        '--token-address', GOERLI_TOKEN_ADDRESS,
-        '--api', 'etherscan-goerli',
-        '--no-dry-run',
-    )
+    for payment_info in TEST_ENOUGH_AMOUNT:
+        WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
-    for order in orders:
+        order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
+
+        call_command(
+            'confirm_payments',
+            '--event-slug', event.slug,
+            '--web3-provider-uri', WEB3_PROVIDER_URI,
+            '--token-address', ROPSTEN_DAI_ADDRESS,
+            '--no-dry-run'
+        )
+
         order.refresh_from_db()
-        assert order.status == order.STATUS_PAID
-
-    for payment in payments:
         payment.refresh_from_db()
+
+        assert order.status == order.STATUS_PAID
         assert payment.state == payment.PAYMENT_STATE_CONFIRMED
 
 
-TEST_LOWER_PAYMENTS = [
-    {'currency_type': 'ETH', 'amount': int('000090000000000001', base=10)},
-    {'currency_type': 'ETH', 'amount': int('000100000000000002', base=10)},
-    {'currency_type': 'ETH', 'amount': int('000900000000000003', base=10)},  # Internal
-    {'currency_type': 'ETH', 'amount': int('000090000000000004', base=10)},  # Internal
-    {'currency_type': 'ETH', 'amount': int('000490000000000005', base=10)},
-    {'currency_type': 'DAI', 'amount': int('090000000000000006', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('100000000000000007', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('200000000000000008', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('300000000000000009', base=10)},  # LAI token
+@skip_if_no_web3_provider
+@pytest.mark.django_db(
+    transaction=True,
+    reset_sequences=True,
+)
+def test_confirm_payment_dry_run(provider, event, get_request_order_payment):
+    provider.settings.set('ETH_RATE', '0.001')
+    provider.settings.set('DAI_RATE', '1.0')
+
+    for payment_info in TEST_ENOUGH_AMOUNT:
+        WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
+
+        order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
+
+        call_command(
+            'confirm_payments',
+            '--event-slug', event.slug,
+            '--web3-provider-uri', WEB3_PROVIDER_URI,
+            '--token-address', ROPSTEN_DAI_ADDRESS,
+        )
+
+        order.refresh_from_db()
+        payment.refresh_from_db()
+
+        assert order.status == order.STATUS_PENDING
+        assert payment.state == payment.PAYMENT_STATE_PENDING
+
+
+TEST_LOWER_AMOUNT = [
+    {'currency': 'ETH', 'amount': int('99000000', base=10),
+     'hex_address': '0xDb9574bf428A612fe13BEFFeB7F4bD8C73BF2D88'},  # Has about 10'000'000 wei
+    {'currency': 'DAI', 'amount': int('99000000', base=10),
+     'hex_address': '0x3d5091A1652e215c71C755BCfA97A08AFC9d6CB0'}   # Has about 32'035 wei
 ]
 
 
-@skip_if_no_etherscan_api_key
+@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payments_works_for_higher_amounts_on_blockchain(get_orders_and_payments):
-    orders, payments = get_orders_and_payments(TEST_LOWER_PAYMENTS)
+def test_confirm_payment_lower_amount(provider, event, get_request_order_payment):
+    provider.settings.set('ETH_RATE', '0.001')
+    provider.settings.set('DAI_RATE', '1.0')
 
-    call_command(
-        'confirm_payments',
-        '--wallet-address', GOERLI_WALLET_ADDRESS,
-        '--token-address', GOERLI_TOKEN_ADDRESS,
-        '--api', 'etherscan-goerli',
-        '--no-dry-run',
-    )
+    for payment_info in TEST_LOWER_AMOUNT:
+        WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
-    for order in orders:
+        order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
+
+        call_command(
+            'confirm_payments',
+            '--event-slug', event.slug,
+            '--web3-provider-uri', WEB3_PROVIDER_URI,
+            '--token-address', ROPSTEN_DAI_ADDRESS,
+            '--no-dry-run'
+        )
+
         order.refresh_from_db()
-        assert order.status == order.STATUS_PAID
-
-    for payment in payments:
         payment.refresh_from_db()
-        assert payment.state == payment.PAYMENT_STATE_CONFIRMED
+
+        assert order.status == order.STATUS_PENDING
+        assert payment.state == payment.PAYMENT_STATE_PENDING
 
 
-TEST_HIGHER_PAYMENTS = [
-    {'currency_type': 'ETH', 'amount': int('000110000000000001', base=10)},
-    {'currency_type': 'ETH', 'amount': int('000210000000000002', base=10)},
-    {'currency_type': 'ETH', 'amount': int('001100000000000003', base=10)},  # Internal
-    {'currency_type': 'ETH', 'amount': int('000110000000000004', base=10)},  # Internal
-    {'currency_type': 'ETH', 'amount': int('000510000000000005', base=10)},
-    {'currency_type': 'DAI', 'amount': int('110000000000000006', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('210000000000000007', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('310000000000000008', base=10)},  # LAI token
-    {'currency_type': 'DAI', 'amount': int('410000000000000009', base=10)},  # LAI token
+TEST_WRONG_CURRENCY = [
+    {'currency': 'DAI', 'amount': int('1000', base=10),
+     'hex_address': '0xb84AC43014d60AE5dCe5d36975eE461f31e953d3'},  # Has enough amount, but in ETH
+    {'currency': 'ETH', 'amount': int('1000', base=10),
+     'hex_address': '0x18FF3A11FAF05F83198A8724006975ce414872Bc'}   # Has enough amount, but in DAI
 ]
 
 
-@skip_if_no_etherscan_api_key
+@skip_if_no_web3_provider
 @pytest.mark.django_db(
     transaction=True,
     reset_sequences=True,
 )
-def test_confirm_payments_skips_lower_amounts_on_blockchain(get_orders_and_payments):
-    orders, payments = get_orders_and_payments(TEST_HIGHER_PAYMENTS)
+def test_confirm_payment_wrong_currency(provider, event, get_request_order_payment):
+    provider.settings.set('ETH_RATE', '0.001')
+    provider.settings.set('DAI_RATE', '1.0')
 
-    call_command(
-        'confirm_payments',
-        '--wallet-address', GOERLI_WALLET_ADDRESS,
-        '--token-address', GOERLI_TOKEN_ADDRESS,
-        '--api', 'etherscan-goerli',
-        '--no-dry-run',
-    )
+    for payment_info in TEST_WRONG_CURRENCY:
+        WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
-    for order in orders:
+        order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
+
+        call_command(
+            'confirm_payments',
+            '--event-slug', event.slug,
+            '--web3-provider-uri', WEB3_PROVIDER_URI,
+            '--token-address', ROPSTEN_DAI_ADDRESS,
+            '--no-dry-run'
+        )
+
         order.refresh_from_db()
-        assert order.status != order.STATUS_PAID
-
-    for payment in payments:
         payment.refresh_from_db()
-        assert payment.state != payment.PAYMENT_STATE_CONFIRMED
 
-
-TEST_WRONG_CURRENCY_PAYMENTS = [
-    {'currency_type': 'DAI', 'amount': int('000100000000000001', base=10)},
-    {'currency_type': 'DAI', 'amount': int('000200000000000002', base=10)},
-    {'currency_type': 'DAI', 'amount': int('001000000000000003', base=10)},  # Internal
-    {'currency_type': 'DAI', 'amount': int('000100000000000004', base=10)},  # Internal
-    {'currency_type': 'DAI', 'amount': int('000500000000000005', base=10)},
-    {'currency_type': 'ETH', 'amount': int('100000000000000006', base=10)},  # LAI token
-    {'currency_type': 'ETH', 'amount': int('200000000000000007', base=10)},  # LAI token
-    {'currency_type': 'ETH', 'amount': int('300000000000000008', base=10)},  # LAI token
-    {'currency_type': 'ETH', 'amount': int('400000000000000009', base=10)},  # LAI token
-]
-
-
-@skip_if_no_etherscan_api_key
-@pytest.mark.django_db(
-    transaction=True,
-    reset_sequences=True,
-)
-def test_confirm_payments_skips_wrong_currency_on_blockchain(get_orders_and_payments):
-    orders, payments = get_orders_and_payments(TEST_WRONG_CURRENCY_PAYMENTS)
-
-    call_command(
-        'confirm_payments',
-        '--wallet-address', GOERLI_WALLET_ADDRESS,
-        '--token-address', GOERLI_TOKEN_ADDRESS,
-        '--api', 'etherscan-goerli',
-        '--no-dry-run',
-    )
-
-    for order in orders:
-        order.refresh_from_db()
-        assert order.status != order.STATUS_PAID
-
-    for payment in payments:
-        payment.refresh_from_db()
-        assert payment.state != payment.PAYMENT_STATE_CONFIRMED
-
-
-@skip_if_no_etherscan_api_key
-@pytest.mark.django_db(
-    transaction=True,
-    reset_sequences=True,
-)
-def test_confirm_payments_does_dry_run_by_default(get_orders_and_payments):
-    orders, payments = get_orders_and_payments(TEST_EQUAL_PAYMENTS)
-
-    call_command(
-        'confirm_payments',
-        '--wallet-address', GOERLI_WALLET_ADDRESS,
-        '--token-address', GOERLI_TOKEN_ADDRESS,
-        '--api', 'etherscan-goerli',
-    )
-
-    for order in orders:
-        order.refresh_from_db()
-        assert order.status != order.STATUS_PAID
-
-    for payment in payments:
-        payment.refresh_from_db()
-        assert payment.state != payment.PAYMENT_STATE_CONFIRMED
+        assert order.status == order.STATUS_PENDING
+        assert payment.state == payment.PAYMENT_STATE_PENDING

--- a/tests/integration/test_confirm_payments.py
+++ b/tests/integration/test_confirm_payments.py
@@ -10,18 +10,23 @@ from pretix_eth.models import WalletAddress
 
 
 WEB3_PROVIDER_URI = os.environ.get('WEB3_PROVIDER_URI')
-ROPSTEN_DAI_ADDRESS = "0xaD6D458402F60fD3Bd25163575031ACDce07538D"
+ROPSTEN_DAI_ADDRESS = '0xaD6D458402F60fD3Bd25163575031ACDce07538D'
 
 
 def check_web3_provider(pytesconfig):
+    # If set to true, any pytest failures will be displayed as if they
+    # happened in the function that called check_web3_provider.
+    # Makes reading logs easier.
     __tracebackhide__ = True
-    if not pytesconfig.getoption("--web3"):
+
+    web3_required = pytesconfig.getoption('--require-web3')
+    if not web3_required:
         pytest.skip(
-            '--web3 flag is not set')
+            '--require-web3 flag is not set')
 
     if WEB3_PROVIDER_URI is None:
         pytest.fail(
-            '--web3 flag is set, but WEB3_PROVIDER_URI is None')
+            '--require-web3 flag is set, but WEB3_PROVIDER_URI is None')
 
 
 @pytest.fixture

--- a/tests/integration/test_confirm_payments.py
+++ b/tests/integration/test_confirm_payments.py
@@ -68,23 +68,30 @@ def test_confirm_payment_enough(provider, event, get_request_order_payment):
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
+    payments = []
+    orders = []
     for payment_info in TEST_ENOUGH_AMOUNT:
         WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
         order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
 
-        call_command(
-            'confirm_payments',
-            '--event-slug', event.slug,
-            '--web3-provider-uri', WEB3_PROVIDER_URI,
-            '--token-address', ROPSTEN_DAI_ADDRESS,
-            '--no-dry-run'
-        )
+        payments.append(payment)
+        orders.append(order)
 
+    call_command(
+        'confirm_payments',
+        '--event-slug', event.slug,
+        '--web3-provider-uri', WEB3_PROVIDER_URI,
+        '--token-address', ROPSTEN_DAI_ADDRESS,
+        '--no-dry-run'
+    )
+
+    for order in orders:
         order.refresh_from_db()
-        payment.refresh_from_db()
-
         assert order.status == order.STATUS_PAID
+
+    for payment in payments:
+        payment.refresh_from_db()
         assert payment.state == payment.PAYMENT_STATE_CONFIRMED
 
 
@@ -97,22 +104,29 @@ def test_confirm_payment_dry_run(provider, event, get_request_order_payment):
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
+    payments = []
+    orders = []
     for payment_info in TEST_ENOUGH_AMOUNT:
         WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
         order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
 
-        call_command(
-            'confirm_payments',
-            '--event-slug', event.slug,
-            '--web3-provider-uri', WEB3_PROVIDER_URI,
-            '--token-address', ROPSTEN_DAI_ADDRESS,
-        )
+        payments.append(payment)
+        orders.append(order)
 
+    call_command(
+        'confirm_payments',
+        '--event-slug', event.slug,
+        '--web3-provider-uri', WEB3_PROVIDER_URI,
+        '--token-address', ROPSTEN_DAI_ADDRESS
+    )
+
+    for order in orders:
         order.refresh_from_db()
-        payment.refresh_from_db()
-
         assert order.status == order.STATUS_PENDING
+
+    for payment in payments:
+        payment.refresh_from_db()
         assert payment.state == payment.PAYMENT_STATE_PENDING
 
 
@@ -133,23 +147,30 @@ def test_confirm_payment_lower_amount(provider, event, get_request_order_payment
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
+    payments = []
+    orders = []
     for payment_info in TEST_LOWER_AMOUNT:
         WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
         order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
 
-        call_command(
-            'confirm_payments',
-            '--event-slug', event.slug,
-            '--web3-provider-uri', WEB3_PROVIDER_URI,
-            '--token-address', ROPSTEN_DAI_ADDRESS,
-            '--no-dry-run'
-        )
+        payments.append(payment)
+        orders.append(order)
 
+    call_command(
+        'confirm_payments',
+        '--event-slug', event.slug,
+        '--web3-provider-uri', WEB3_PROVIDER_URI,
+        '--token-address', ROPSTEN_DAI_ADDRESS,
+        '--no-dry-run'
+    )
+
+    for order in orders:
         order.refresh_from_db()
-        payment.refresh_from_db()
-
         assert order.status == order.STATUS_PENDING
+
+    for payment in payments:
+        payment.refresh_from_db()
         assert payment.state == payment.PAYMENT_STATE_PENDING
 
 
@@ -170,21 +191,28 @@ def test_confirm_payment_wrong_currency(provider, event, get_request_order_payme
     provider.settings.set('ETH_RATE', '0.001')
     provider.settings.set('DAI_RATE', '1.0')
 
+    payments = []
+    orders = []
     for payment_info in TEST_WRONG_CURRENCY:
         WalletAddress.objects.create(hex_address=payment_info['hex_address'], event=event)
 
         order, payment = make_order_payment(payment_info, provider, get_request_order_payment)
 
-        call_command(
-            'confirm_payments',
-            '--event-slug', event.slug,
-            '--web3-provider-uri', WEB3_PROVIDER_URI,
-            '--token-address', ROPSTEN_DAI_ADDRESS,
-            '--no-dry-run'
-        )
+        payments.append(payment)
+        orders.append(order)
 
+    call_command(
+        'confirm_payments',
+        '--event-slug', event.slug,
+        '--web3-provider-uri', WEB3_PROVIDER_URI,
+        '--token-address', ROPSTEN_DAI_ADDRESS,
+        '--no-dry-run'
+    )
+
+    for order in orders:
         order.refresh_from_db()
-        payment.refresh_from_db()
-
         assert order.status == order.STATUS_PENDING
+
+    for payment in payments:
+        payment.refresh_from_db()
         assert payment.state == payment.PAYMENT_STATE_PENDING

--- a/tests/integration/test_confirm_payments.py
+++ b/tests/integration/test_confirm_payments.py
@@ -9,7 +9,7 @@ from django.test import RequestFactory
 from pretix_eth.models import WalletAddress
 
 
-WEB3_PROVIDER_URI = 'wss://ropsten.infura.io/ws/v3/7c8da79a6f0e4485be91055385dbcd38'
+WEB3_PROVIDER_URI = os.environ.get('WEB3_PROVIDER_URI')
 skip_if_no_web3_provider = pytest.mark.skipif(
     WEB3_PROVIDER_URI is None,
     reason='Web3 provider uri is not set',


### PR DESCRIPTION
### What was wrong?

Tests for the confirm_payments command were outdated. Related to #120 

### How was it fixed?

Implemented new tests by creating several wallets with some balance on Ropsten Testnet. For testing it will require having a web3 provider uri, otherwise, tests will be skipped. 

Testing scenarios:
1. Payment to the wallet was made and it is sufficient (current_wallet_amount >= expected_amount). No dry run, modifies the database.
2. Same as in 1, but with a dry run. No modification in the database is made.
3. Payment was made, but the amount is less than expected.
4. Payment was made, but in the wrong currency e.g. payment is in DAI, but we were expecting ETH. 

#### Cute Animal Picture

![Cute animal picture](https://www.verywellmind.com/thmb/8quBdAdGoHUYoLON4FDQwPnlZl0=/500x350/filters:no_upscale():max_bytes(150000):strip_icc()/iStock-619961796-edit-59cabaf6845b3400111119b7.jpg)
