### PR TITLE
display already set settings values in admin

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -86,6 +86,7 @@ class Ethereum(BasePaymentProvider):
             ]
         )
 
+        form_fields['_NETWORKS']._as_type = list
         return form_fields
 
     def get_token_rates_from_admin_settings(self):


### PR DESCRIPTION
Fill properly the `initial` values of Django Forms, in the way it is handled in Pretix [1]

[1] https://github.com/pretix/pretix/blob/4c3192f1168e16c443f3d56020afdab1fffe9704/src/pretix/base/payment.py#L381

Resolves https://github.com/esPass/pretix-eth-payment-plugin/issues/164