### PR TITLE
update token rate instructions for multiple fiat currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In the process tooling like [Web3Modal](https://github.com/Web3Modal/web3modal/)
     ```
     {"ETH_RATE": 4000, "DAI_RATE": 1}
     ```
-    i.e. `KEY` = `<CRYPTO_SMBOL>_RATE` and `VALUE` = value of 1 unit in your fiat currency e.g. USD. For USD, above example says 1 ETH = 4000$
+    i.e. `KEY` = `<CRYPTO_SMBOL>_RATE` and `VALUE` = value of 1 unit in your fiat currency e.g. USD, EUR etc. For USD, above example says 1 ETH = 4000$. If EUR was chosen, then this says 1 ETH = 4000EUR.
   - Select the networks you want under the "Networks" option - Choose from Ethereum Mainnet, Optimism, Arbitrum and their testnets.
   - "NETWORK_RPC_URLS" - This is a JSON e.g.
     ```

--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -51,7 +51,7 @@ class Ethereum(BasePaymentProvider):
                     forms.JSONField(
                         label=_("Token Rate"),
                         help_text=_(
-                            "JSON field with key = {TOKEN_SYMBOL}_RATE and value = amount for a token in USD. E.g. 'ETH_RATE':4000."  # noqa: E501
+                            "JSON field with key = {TOKEN_SYMBOL}_RATE and value = amount for a token in the fiat currency you have chosen. E.g. 'ETH_RATE':4000 means 1 ETH = 4000 in the fiat currency."  # noqa: E501
                         ),
                     ),
                 ),


### PR DESCRIPTION
make it clear that token rates aren't for USD but for whatever fiat currency you choose at the time of setup