### PR TITLE
Resolve dependencies that cause pip install to backtrack way indefinitely

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -40,7 +40,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install -e .[dev] --use-deprecated=legacy-resolver
+
     - name: ${{ matrix.toxenv }}
       run: tox 
       env: 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            toxenv: py36-core
-          - python-version: 3.6
-            toxenv: py36-integration
+          #- python-version: 3.6
+          #  toxenv: py36-core
+          #- python-version: 3.6
+          #  toxenv: py36-integration
           - python-version: 3.7
             toxenv: py37-core
           - python-version: 3.7

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -16,6 +16,10 @@ jobs:
             toxenv: py38-core
           - python-version: 3.8
             toxenv: py38-integration
+          - python-version: 3.9
+            toxenv: py39-core
+          - python-version: 3.9
+            toxenv: py39-integration
           - python-version: 3.8
             toxenv: lint
           

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel setuptools
         pip install -e .[dev] --use-deprecated=legacy-resolver
 
     - name: ${{ matrix.toxenv }}

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -36,7 +36,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip wheel setuptools
-        pip install -e .[dev] --use-deprecated=legacy-resolver
+        pip install -e .[dev]
 
     - name: ${{ matrix.toxenv }}
       run: tox 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,10 +8,6 @@ jobs:
     strategy:
       matrix:
         include:
-          #- python-version: 3.6
-          #  toxenv: py36-core
-          #- python-version: 3.6
-          #  toxenv: py36-integration
           - python-version: 3.7
             toxenv: py37-core
           - python-version: 3.7

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -38,6 +38,9 @@ jobs:
         python -m pip install --upgrade pip wheel setuptools
         pip install -e .[dev]
 
+    - name: Pip Check
+      run: pip check
+
     - name: ${{ matrix.toxenv }}
       run: tox 
       env: 

--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,6 @@ data/
 
 # Editor / IDE
 .vscode
+/.idea
 
 venv

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In the process tooling like [Web3Modal](https://github.com/Web3Modal/web3modal/)
 
 ## Event Setup Instructions
 1. Under the event, go to Settings -> Plugins -> Payment Providers -> click on Enable under "Pretix Ethereum Payment Provider" 
-2. Next, under Settings, go to Payments -> "ETH or DAI" -> Settings -> click on "enable payment option". 
+2. Next, under Settings, go to Payments -> "ETH or DAI" -> Settings -> click on "enable payment method". 
 3. Next, scroll down and set the values for the following:
   - "TOKEN_RATE" - This is a JSON e.g. 
     ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In the process tooling like [Web3Modal](https://github.com/Web3Modal/web3modal/)
 1. Clone this repository, e.g. to `local/pretix-eth-payment-plugin`.
 1. Create and activate a virtual environment.
 1. Execute `pip install -e .[dev]` within the `pretix-eth-payment-plugin` repo
-   directory.
+   directory. If pip install takes too long, run it with `--use-deprecated=legacy-resolver`.
 1. Setup a local database by running `make devmigrate`.
 1. Fire up a local dev server by running `make devserver`.
 1. Visit http://localhost:8000/control/login in a browser windows and enter

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In the process tooling like [Web3Modal](https://github.com/Web3Modal/web3modal/)
 1. Clone this repository, e.g. to `local/pretix-eth-payment-plugin`.
 1. Create and activate a virtual environment.
 1. Execute `pip install -e .[dev]` within the `pretix-eth-payment-plugin` repo
-   directory. If pip install takes too long, run it with `--use-deprecated=legacy-resolver`.
+   directory.
 1. Setup a local database by running `make devmigrate`.
 1. Fire up a local dev server by running `make devserver`.
 1. Visit http://localhost:8000/control/login in a browser windows and enter

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(
     install_requires=[
         "pretix>=3.8.0",
         "web3>=5.7.0",
-        "eth-abi>=2.1.1,<4",
-        "eth-typing>=2.2.1,<4",
-        "eth-utils>=1.8.4,<3",
+        "eth-abi>=2.1.1,<3",
+        "eth-typing>=2.2.1,<3",
+        "eth-utils>=1.8.4,<2",
         "eth-hash[pycryptodome]>=0.3.1,<0.4",
         # Requests requires urllib3 <1.26.0.  Can delete this later after
         # requests gets its act together.

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         # requests gets its act together.
         "urllib3<1.27.0",
     ],
-    python_requires='>=3.6, <4',
+    python_requires='>=3.7, <4',
     extras_require=extras_require,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist=
     py{37,38,39}-{core,integration}
     lint
+setenv=
+    VIRTUALENV_PIP=21.0.0
 
 [flake8]
 max-line-length= 100

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,38}-{core,integration}
+    py{37,38,39}-{core,integration}
     lint
 
 [flake8]
@@ -14,9 +14,9 @@ commands=
     integration: pytest {posargs:tests/integration}
 extras=test
 basepython=
+    py39: python3.9
     py38: python3.8
     py37: python3.7
-    py36: python3.6
 passenv=
     ETHERSCAN_API_KEY
 


### PR DESCRIPTION
### What was wrong?

A recent change in `pip` dependency resolving strategy causes CI pipelines and local development setup to timeout, but unambiguous package requirements are resolved quickly with new pip resolver. 

### How was it fixed?

This situation can be verified by running pip check, but usually CI would time-out even before getting this far in the CI action list.

* resolved dependency isssues
* added `pip check` to CI pipeline

#### Cute Animal Picture

![baby-newt](https://user-images.githubusercontent.com/7071027/158209147-6c1ac358-8e37-458a-86c7-3a7eb35b0828.jpeg)
